### PR TITLE
Mejora: separar_facturas — agrupación robusta y normalización OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,171 @@
-# 🧾 Unir  Facturas y Albaranes
+# Automatización de Facturas y Albaranes – ERP → PDF
 
-Un programa sencillo para uso administrativo que permite **combinar automáticamente facturas  PDF con sus albaranes correspondientes**, generando un único archivo final por cada factura.  
-Ideal para contables, administrativos o responsables de archivo digital que trabajan con facturas y albaranes en formato PDF.
+Este proyecto proporciona un conjunto de herramientas diseñadas para automatizar el tratamiento documental de facturas y albaranes generados desde un ERP.  
+Los módulos permiten:
 
----
+1. Separar un PDF único que contiene varias facturas en PDFs individuales.  
+2. Renombrar automáticamente los albaranes según su número y fecha.  
+3. Unir cada factura con todos los albaranes que le corresponden (en desarrollo).  
+4. Estructurar carpetas de trabajo de forma estándar y asistida.
 
-## 🎯 ¿Para qué sirve?
-
-Cuando una factura incluye uno o varios albaranes (documentos de entrega) que están en PDF por separado, este programa:
-
-- Identifica el **número de factura** y el **nombre del cliente** que aparecen en la factura.  
-- Extrae los números de los albaranes que figuran en la factura (por ejemplo: “Albarán Núm. A25  487 de 07/04/2025”).  
-- Busca automáticamente esos albaranes en una carpeta — y en **subcarpetas también** —.  
-- Une la factura + sus albaranes en un solo PDF con nombre claro (fecha, factura, cliente).  
-- Genera un registro de actividad (log) con las facturas procesadas, los albaranes encontrados o no encontrados, y los resultados finales.
-
-Esto permite tener un archivo único por factura, listo para archivar, firmar digitalmente o enviar al cliente.
+El proyecto está orientado a entornos administrativos, con enfoque práctico, sin requerir conocimientos técnicos avanzados.
 
 ---
 
-## 📂 Estructura del repositorio
+## Estado actual del proyecto
+
+### 🟢 Módulos completados
+- **separar_facturas.py**  
+  Divide un PDF con múltiples facturas en PDFs individuales, agrupando las páginas de cada factura y asignando nombres estandarizados.  
+  Usa OCR (Tesseract) para detectar número de factura y fecha en un recuadro fijo.
+
+- **procesar_albaranes.py**  
+  Renombra albaranes PDF según su número y fecha, siguiendo un patrón fijo basado en la lectura OCR de un recuadro estructurado.
+
+### 🟡 Módulos en desarrollo
+- **unir_facturas_albaranes.py**  
+  Unirá cada factura con sus albaranes correspondientes.  
+  El módulo está iniciado y contiene detección preliminar de números de factura y albaranes.  
+  Será actualizado para asumir que la identificación de factura (número y fecha) ya la aporta el módulo `separar_facturas.py`.
+
+### 🟡 Estructura del proyecto  
+Conjunto de subcarpetas y convenciones de nombres para automatizar totalmente el flujo de ERP → PDFs → Carpetas → Fusionado.
+
+---
+
+## Estructura del repositorio
 
 ```
-unir-facturas-albaranes/
-├── src/                                  # Código fuente (.py)
-│   └── unir_facturas_albaranes.py        # Script principal
-├── dist/                                 # Ejecutables generados (.exe) cuando el script es compilado
-├── logs/                                 # Carpetas de registros de ejecución
-├── README.md                             # Este archivo: información del proyecto
-└── LICENSE (opcional)                    # Licencia del proyecto
+/ (raíz)
+│
+├─ README.md               ← este documento
+├─ requirements.txt
+├─ USAGE.md                ← instrucciones ampliadas (opcional)
+│
+├─ src/
+│   ├─ separar_facturas.py
+│   ├─ procesar_albaranes.py
+│   └─ unir_facturas_albaranes.py
+│
+├─ logs/
+│   └─ (generado automáticamente)
+│
+└─ dist/                   ← aquí se guardan los .exe generados
 ```
 
 ---
 
-## ⚙️ Requisitos
+# Funcionamiento de cada módulo
 
-### 🔧 Software
+## 1. separarar_facturas.py
+**Objetivo:**  
+Dado un único PDF exportado desde el ERP con todas las facturas (una por página o varias páginas por factura), divide y genera un PDF por factura.
 
-- Windows 10  o 11  
-- Python 3.10 o superior (si usa el script `.py` directamente)  
-  - Para usar como ejecutable `.exe` no se necesita saber Python.  
-- (Opcional) PyInstaller, si desea generar su propio `.exe`.
+**Características:**
+- Detección del número de factura dentro del recuadro superior-izquierdo.
+- Correcciones internas del OCR para evitar errores típicos (0/O, 1/I/l, S/5, Z/2…)
+- Agrupación de páginas consecutivas que pertenecen a la misma factura.
+- Nombres de salida con formato:
+  ```
+  YYYY-MM-DD FE#NNNN SERIE.pdf
+  ```
+- GUI completa con selección de archivo origen, carpeta destino y barra de progreso.
 
-### 📦 Librerías utilizadas y por qué
+**Entrada:**  
+Un PDF único (ej.: `2025-10-2Q FACTURAS.pdf`)
 
-| Librería           | ¿Para qué se usa?                                                |
-|---------------------|-----------------------------------------------------------------|
-| `PyMuPDF` (alias `fitz`) | Permite abrir PDFs, extraer texto y bloques de texto (posiciones) para identificar nombres y albaranes. |
-| `PyPDF2`             | Permite combinar varios PDFs (factura + albaranes) en un único archivo. |
-| `tkinter`           | Proporciona ventanas gráficas para que el usuario seleccione las carpetas sin usar consola. |
-| `tqdm`              | Proporciona barra de progreso cuando se ejecuta en consola (aunque en el `.exe` gráfico se suprime). |
-| `logging`           | Registra en un archivo “log” todo el proceso: qué facturas, qué albaranes, qué errores. |
-
----
-
-## 🚀 Instalación del script
-
-Si desea usar el script directamente (.py):
-
-1. Instale Python 3.10+ si aún no lo tiene.  
-2. Descargue o clone este repositorio.  
-3. Abra una terminal en la carpeta `src/`.  
-4. Instale las dependencias:
-   ```bash
-   pip install PyMuPDF PyPDF2 tqdm
-   ```
-5. Ejecute:
-   ```bash
-   python unir_facturas_albaranes.py
-   ```
-
-### 🖥️ Si desea usarlo como ejecutable (.exe)
-
-1. Instale PyInstaller:
-   ```bash
-   pip install pyinstaller
-   ```
-2. En la carpeta `src/`, ejecute:
-   ```bash
-   pyinstaller --onefile --noconsole "unir_facturas_albaranes.py"
-   ```
-3. Se generará el archivo `dist\unir_facturas_albaranes.exe`. Copie‑pegué ese `.exe` en la carpeta que desee y ejecútelo con doble‑clic.
+**Salida:**  
+PDFs individuales en la carpeta destino.
 
 ---
 
-## 🧾 Uso paso a paso (usuario no técnico)
+## 2. procesar_albaranes.py
+**Objetivo:**  
+Renombrar los albaranes usando los datos del recuadro superior-izquierdo (Número, Fecha, Cliente).
 
-1. Doble‑clic para abrir el programa (o ejecute al script).  
-2. Aparecerá un mensaje explicativo. Luego se le pedirá que **seleccione tres carpetas**, en este orden:
-   - Carpeta donde están **las facturas a procesar**.  
-   - Carpeta base donde se encuentran **los albaranes** (puede contener subcarpetas).  
-   - Carpeta de **destino**, donde desea que se guarden los PDFs combinados.  
-3. El programa comenzará a procesar. Aparecerá al finalizar un mensaje “Proceso completado”.  
-4. Abra la carpeta de destino: verá archivos con nombres tipo:  
-   ```
-   2025‑10‑31 FE#1106 NOMBRE_CLIENTE.pdf
-   ```
-5. Abra también la carpeta `logs` y verá el archivo `procesa_facturas_log.txt`, donde podrá revisar los detalles:  
-   - Facturas procesadas.  
-   - Albaranes encontrados o faltantes.  
-   - Facturas sin albaranes o albaranes no usados.
+**Características:**
+- OCR preciso en coordenadas fijas.
+- Nombres estandarizados.
+- Limpieza automática de formatos.
 
 ---
 
-## 🧠 Buenas prácticas para uso administrativo
+## 3. unir_facturas_albaranes.py
+**Objetivo:**  
+Fusionar cada factura con todos sus albaranes relacionados.  
+Este módulo:
+- Localizará los albaranes pertenecientes a cada factura.
+- Integrará en un único PDF la factura + sus albaranes.
+- Usará la nomenclatura estándar establecida por los módulos anteriores.
 
-- Asegúrese de que las facturas en la carpeta “facturas a procesar” ya estén **renombradas** en formato `AAAA‑MM‑DD FE#nnnn` seguido del cliente, **si ya fuera necesario** (el script añadirá el nombre del cliente si lo encuentra).  
-- Verifique que la carpeta de albaranes incluya todos los archivos PDF de albaranes (por ejemplo, organizados por año o quincena). El script busca en subcarpetas automáticamente.  
-- Una vez generado el archivo combinado, archive la factura original y los albaranes correspondientes si lo desea — el programa no los borra ni mueve por usted.  
-- Revise el log al menos una vez al mes para detectar albaranes no encontrados o facturas sin albaranes — así podrá completar su archivo antes de enviarlo al archivo digital o firma.
-
----
-
-## ✨ ¿Qué pasa “detrás de cámaras”?
-
-1. El programa abre cada factura en PDF y extrae el **nombre del cliente**, mediante análisis de bloque de texto en la zona superior‑derecha del documento.  
-2. Luego extrae del texto de la factura los números de albarán que figuran (por ejemplo “A25 1345”).  
-3. Por cada número de albarán, busca en la carpeta de albaranes (y subcarpetas) el archivo PDF cuyo nombre contenga ese número.  
-4. Crea un PDF nuevo que incorpora **primero la factura** y luego, en el orden detectado, **los albaranes**.  
-5. Guarda ese PDF en la carpeta de destino y registra todo el proceso en el log.
+**Estado:**  
+Iniciado, pendiente de adaptación a la nueva lógica del separador de facturas.
 
 ---
 
-## 🧪 Limitaciones conocidas
+# Requisitos
 
-- Si el PDF de factura no está bien generado (por ejemplo, es un escaneo sin OCR), el reconocimiento del cliente o de los números de albarán puede fallar.  
-- Si el nombre del cliente no está en la zona esperada (superior‑derecha) o está dividido en más de una línea, puede no detectarse correctamente — revise entonces el archivo final y modifique manualmente si es necesario.  
-- Si varios albaranes tienen **exactamente el mismo número** o rutas idénticas, puede generarse un duplicado — revise el log para corregirlos.
+El proyecto requiere:
+
+```
+pymupdf>=1.24
+pillow>=10.0
+pytesseract>=0.3
+pypdf>=4.0
+```
+
+Tesseract debe estar instalado manualmente en Windows:
+
+Ruta recomendada:
+```
+C:\Program Files\Tesseract-OCR\tesseract.exe
+```
 
 ---
 
-## 📣 Colaboración y mejoras
+# Instalación
 
-Este proyecto lo desarrolla **Rafael Seaje** (contable y desarrollador de automatización).  
-Si desea proponer mejoras, activar OCR para facturas escaneadas o integrar en un sistema de firma digital, puede **crear un “Issue”** en este repositorio.
+1. Instalar Python 3.9+  
+2. Instalar dependencias:
+
+```
+pip install -r requirements.txt
+```
+
+3. Asegurar la instalación de Tesseract OCR.
 
 ---
 
-## 📜 Licencia
+# Compilación a .exe (si se desea)
 
-Este proyecto es para **uso personal o interno**. Está permitido modificarlo según sus necesidades, **pero no se publica como producto comercial sin permiso del autor**.
+Ejemplo para `separar_facturas.py`:
+
+```
+pyinstaller --onefile --noconsole ^
+  --add-data "logs;logs" ^
+  --name "SepararFacturas" src/separar_facturas.py
+```
+
+El ejecutable aparece en `dist/`.
 
 ---
 
-### ✅ En resumen
+# Uso general (resumen)
 
-Unir  Facturas  y  Albaranes es una herramienta creada para facilitar y automatizar el trabajo administrativo de combinar facturas y albaranes en formato PDF, con un proceso guiado, registros de actividad y buen nivel de autonomía para usuarios sin conocimientos profundos de programación.
+### Módulo 1 – Separar facturas
+1. Ejecutar el `.exe` o el `.py`  
+2. Elegir PDF origen  
+3. Elegir carpeta destino  
+4. Pulsar “INICIAR SEPARACIÓN”
+
+### Módulo 2 – Renombrar albaranes
+1. Ejecutar el módulo  
+2. Seleccionar carpeta con albaranes  
+3. Procesar
+
+### Módulo 3 – Unir facturas + albaranes (en desarrollo)
+
+---
+
+# Licencia
+Pendiente de definir.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,44 @@
+# Instrucciones de uso
+
+## 1. Separar facturas (separar_facturas.py)
+
+1. Abrir el ejecutable o correr:
+   ```
+   python src/separar_facturas.py
+   ```
+2. Seleccionar el PDF origen que contiene todas las facturas.
+3. Elegir carpeta destino.
+4. Pulsar "INICIAR SEPARACIÓN".
+5. El sistema generará:
+   - un PDF por factura
+   - log en `logs/separar_facturas.log`
+
+---
+
+## 2. Renombrar albaranes (procesar_albaranes.py)
+
+1. Ejecutar:
+   ```
+   python src/procesar_albaranes.py
+   ```
+2. Seleccionar carpeta con albaranes.
+3. Confirmar procesamiento.
+4. Los PDFs se renombrarán según su número y fecha.
+
+---
+
+## 3. Unir facturas + albaranes (unir_facturas_albaranes.py)
+
+En desarrollo.  
+El funcionamiento final será:
+
+1. Leer facturas ya separadas y renombradas.  
+2. Buscar sus albaranes correspondientes.
+3. Generar un PDF fusionado por factura.
+
+---
+
+## Notas importantes
+
+- Tesseract debe estar instalado en el sistema.  
+- Los ejecutables se generan en `dist/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-PyMuPDF
-PyPDF2
-pytesseract
-pillow
-pdf2image
-tqdm
-tk
+pymupdf>=1.24
+pillow>=10.0
+pytesseract>=0.3
+pypdf>=4.0

--- a/src/separar_facturas.py
+++ b/src/separar_facturas.py
@@ -2,442 +2,456 @@
 # -*- coding: utf-8 -*-
 """
 separar_facturas.py
-Módulo para dividir un PDF que contiene muchas facturas en PDFs individuales por factura.
-Detecta número de factura y fecha en el rectángulo superior-izq (coordenadas en cm), 
-extrae nombre de cliente desde bloques en la zona superior-derecha y renombra cada PDF
-según el patrón: YYYY-MM-DD FE#NNNN NOMBRE_CLIENTE.pdf
+Módulo para separar un PDF que contiene muchas facturas en PDFs individuales,
+agrupando páginas que pertenecen a la misma factura.
 
-Requisitos:
-  pip install PyMuPDF Pillow pytesseract pypdf
-  Tesseract instalado en: C:\Program Files\Tesseract-OCR\tesseract.exe
+Versión corregida:
+ - Normaliza la "clave" de factura para evitar que pequeñas variaciones OCR
+   provoquen que páginas de la misma factura se separen.
+ - Mantiene la lógica original de OCR/recorte pero estabiliza la comparación.
 """
 
 import os
 import re
+import threading
+import datetime
 import logging
-import shutil
-from datetime import datetime
 from io import BytesIO
 
-import fitz  # PyMuPDF
-from PIL import Image, ImageOps, ImageFilter, ImageEnhance
+import fitz                     # PyMuPDF
+from PIL import Image
 import pytesseract
 from pypdf import PdfReader, PdfWriter
-
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
 # -------------------- CONFIGURACIÓN --------------------
-# Ruta a tesseract (confirmada)
+# Ruta a tesseract (ajusta si en tu equipo es diferente - ya la tenemos).
 pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
 
-# Rectángulo del número/fecha de factura (cm desde borde superior-izq)
-RECT_FACT_LEFT_CM = 0.7
-RECT_FACT_TOP_CM = 5.7
-RECT_FACT_RIGHT_CM = 7.6
-RECT_FACT_BOTTOM_CM = 7.5
-PAD_CM = 0.15  # pequeño padding por seguridad
+# Rectángulo del número/fecha de factura en mm sobre A4:
+RECT_MM = {"left_mm": 7.0, "width_mm": 68.0, "top_mm": 57.0, "height_mm": 17.0}
 
-# DPI para renderizado
-RENDER_DPI = 300
+# DPI / zoom para renderizado: mayor zoom → mejor OCR, pero más tiempo/uso memoria
+RENDER_ZOOM = 2.0
 
-# Carpeta de logs
-LOGS_DIR = "logs"
-FAIL_IMG_DIR = os.path.join(LOGS_DIR, "fails_images")
+# Carpeta de logs (se sobrescribe a cada ejecución)
+LOG_DIR = "logs"
+LOG_FILE = os.path.join(LOG_DIR, "separar_facturas.log")
 
-# Regex para detectar número de factura y fecha
-RE_FACTURA = re.compile(r'Factura[:\s]*([A-Za-z0-9\-/]+|\d{1,})', re.IGNORECASE)  # captura lo que sigue a "Factura:"
-# Si las facturas numericas son solo dígitos, lo extraemos con:
-RE_FACTURA_NUM = re.compile(r'(\d{1,})')
-RE_FECHA = re.compile(r'Fecha[:\s]*([0-3]?\d/[01]?\d/[12]\d{3})', re.IGNORECASE)
+# Regex para detectar número/serie y fecha
+RE_SERIE_NUM = re.compile(r'^\s*([A-Za-z]{1,5})?\s*([0-9]{1,4})\b', re.IGNORECASE)
+RE_FECHA = re.compile(r'([0-3]?\d/[01]?\d/[12]\d{3})')
 
-# Sufijos societarios a eliminar del nombre del cliente
-SUFFIXES_RE = re.compile(r'\b(SL|SA|SLU|SCOOP|SLL|SCOOPG|SC|S\.L\.|S\.A\.)\b\.?$', re.IGNORECASE)
+# Mapa de corrección de confusiones OCR típicas (aplicado solo en la porción numérica)
+OCR_CONFUSION_MAP = str.maketrans({
+    'O': '0', 'o': '0',
+    'I': '1', 'l': '1', '|': '1',
+    'Z': '2',
+    'S': '5',
+    'B': '8',
+    '—': '-', '–': '-'
+})
 
-# -------------------- UTILIDADES --------------------
+# -------------------- LOGGER --------------------
 def configurar_logger():
-    os.makedirs(LOGS_DIR, exist_ok=True)
-    os.makedirs(FAIL_IMG_DIR, exist_ok=True)
-    logname = datetime.now().strftime("separar_facturas_%Y%m%d_%H%M%S.log")
-    logpath = os.path.join(LOGS_DIR, logname)
-    logging.basicConfig(filename=logpath,
-                        level=logging.INFO,
-                        format="%(asctime)s - %(levelname)s - %(message)s")
+    os.makedirs(LOG_DIR, exist_ok=True)
+    logging.basicConfig(
+        filename=LOG_FILE,
+        filemode='w',  # sobreescribir cada ejecución
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    # también emitir a consola útil cuando se ejecuta en python directamente
+    if not any(isinstance(h, logging.StreamHandler) for h in logging.getLogger().handlers):
+        logging.getLogger().addHandler(logging.StreamHandler())
     logging.info("=== INICIO: separar_facturas ===")
-    return logpath
+    logging.info(f"RECT_MM: {RECT_MM}, RENDER_ZOOM: {RENDER_ZOOM}")
 
-def cm_to_points(cm):
-    return cm * (72.0 / 2.54)
+# -------------------- UTILIDADES OCR / IMAGEN --------------------
+def render_page_to_image(page, zoom=RENDER_ZOOM):
+    mat = fitz.Matrix(zoom, zoom)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+    img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+    return img
 
-def limpiar_nombre_cliente(nombre: str) -> str:
-    if not nombre:
-        return "CLIENTE"
-    s = nombre.strip()
-    s = s.replace('.', '')
-    s = re.sub(SUFFIXES_RE, '', s).strip()
-    s = re.sub(r'\s{2,}', ' ', s)
-    s = re.sub(r'[\/\\\:\*\?\"\<\>\|]', '_', s)
-    return s.upper()
+def crop_region_from_image(img, page_width_pts, page_height_pts):
+    pts_per_mm = 72.0 / 25.4
+    left_pt = RECT_MM["left_mm"] * pts_per_mm
+    top_pt = RECT_MM["top_mm"] * pts_per_mm
+    right_pt = (RECT_MM["left_mm"] + RECT_MM["width_mm"]) * pts_per_mm
+    bottom_pt = (RECT_MM["top_mm"] + RECT_MM["height_mm"]) * pts_per_mm
 
-# Extrae texto del bloque de interés usando PyMuPDF blocks
-def extraer_texto_rect(page, rect):
-    """
-    Devuelve el texto extraído dentro del rect (fitz.Rect)
-    """
-    try:
-        blocks = page.get_text("blocks")  # lista de (x0,y0,x1,y1, "text", block_no)
-    except Exception as e:
-        logging.error(f"get_text('blocks') falló: {e}")
-        return ""
-    textos = []
-    for b in blocks:
-        x0, y0, x1, y1, btext, _ = b
-        # comprobar intersección con rect
-        if x1 >= rect.x0 and x0 <= rect.x1 and y1 >= rect.y0 and y0 <= rect.y1:
-            textos.append(btext)
-    return "\n".join(textos).strip()
+    # expandimos ligeramente el recorte para evitar cortes (margen de seguridad)
+    MARGIN_H_PCT = 0.10  # 10% horizontal
+    MARGIN_V_PCT = 0.15  # 15% vertical
 
-def render_rect_image(page, rect, dpi=RENDER_DPI):
-    """
-    Renderiza la región rect (fitz.Rect) de la página a PIL.Image RGB.
-    """
-    try:
-        mat = fitz.Matrix(dpi/72.0, dpi/72.0)
-        pix = page.get_pixmap(matrix=mat, clip=rect, alpha=False)
-        img = Image.open(BytesIO(pix.tobytes("png"))).convert("RGB")
-        return img
-    except Exception as e:
-        logging.error(f"render_rect_image falló: {e}")
+    width_pt = right_pt - left_pt
+    height_pt = bottom_pt - top_pt
+
+    left_pt = max(0, left_pt - width_pt * MARGIN_H_PCT)
+    right_pt = right_pt + width_pt * MARGIN_H_PCT
+    top_pt = max(0, top_pt - height_pt * MARGIN_V_PCT)
+    bottom_pt = bottom_pt + height_pt * MARGIN_V_PCT
+
+    scale = RENDER_ZOOM
+    left_px = int(round(left_pt * scale))
+    top_px = int(round(top_pt * scale))
+    right_px = int(round(right_pt * scale))
+    bottom_px = int(round(bottom_pt * scale))
+
+    left_px = max(0, left_px)
+    top_px = max(0, top_px)
+    right_px = min(img.width, right_px)
+    bottom_px = min(img.height, bottom_px)
+
+    if right_px <= left_px or bottom_px <= top_px:
         return None
 
-def preprocess_for_ocr(img: Image.Image) -> Image.Image:
-    """
-    Preprocesado simple para OCR: escala, gris, contraste, unsharp
-    """
-    img = img.convert("RGB")
-    w,h = img.size
-    img = img.resize((int(w*2), int(h*2)), Image.BICUBIC)
-    gray = ImageOps.grayscale(img)
-    enh = ImageEnhance.Contrast(gray)
-    gray = enh.enhance(1.3)
-    gray = gray.filter(ImageFilter.MedianFilter(size=3))
-    gray = gray.filter(ImageFilter.UnsharpMask(radius=1, percent=120, threshold=3))
-    return gray
+    return img.crop((left_px, top_px, right_px, bottom_px))
 
-def ocr_image_to_text(img: Image.Image, config="--psm 6"):
+def ocr_image_to_text(img):
     try:
-        text = pytesseract.image_to_string(img, lang='spa', config=config)
+        gray = img.convert("L")
+        text = pytesseract.image_to_string(gray, lang='spa', config="--psm 6")
+        text = text.replace('\r', '\n').strip()
         return text
     except Exception as e:
         logging.error(f"OCR falló: {e}")
         return ""
 
-# -------------------- LÓGICA DE DETECCIÓN EN UNA PÁGINA --------------------
-def detectar_en_pagina(page):
+# -------------------- EXTRACCIÓN Y NORMALIZACIÓN --------------------
+def normalize_numeric_part(s):
     """
-    Detecta número de factura, fecha y cliente en una página (fitz page).
-    Devuelve (numero_string_or_None, fecha_iso_or_None, cliente_or_None, debug_text)
+    Normaliza una cadena intentando corregir confusiones OCR típicas
+    y extraer la porción numérica inicial.
+    Devuelve la porción numérica como string (sin ceros a la izquierda) o None.
     """
-    # calcular rect en puntos
-    left = cm_to_points(max(0.0, RECT_FACT_LEFT_CM - PAD_CM))
-    top = cm_to_points(max(0.0, RECT_FACT_TOP_CM - PAD_CM))
-    right = cm_to_points(RECT_FACT_RIGHT_CM + PAD_CM)
-    bottom = cm_to_points(RECT_FACT_BOTTOM_CM + PAD_CM)
-    rect = fitz.Rect(left, top, right, bottom)
+    if not s:
+        return None
+    # aplicar map de confusiones (solo para facilitar detección)
+    s_mapped = s.translate(OCR_CONFUSION_MAP)
+    # buscar primero 'serie + número' patrón
+    m = RE_SERIE_NUM.match(s_mapped)
+    if m:
+        serie = (m.group(1) or "").strip().upper()
+        num = m.group(2)
+        # devolver num sin ceros a la izquierda (pero manteniendo "0" si es "0")
+        return serie if serie else "", num.lstrip('0') or num
+    # si no hay serie+num al inicio, buscar primer grupo de 1-4 dígitos
+    m2 = re.search(r'([0-9]{1,4})', s_mapped)
+    if m2:
+        return "", m2.group(1).lstrip('0') or m2.group(1)
+    return None
 
-    # 1) intentar extraer texto directo de ese rect (si el PDF tiene texto)
-    texto_rect = extraer_texto_rect(page, rect)
-    numero = None
+def extract_number_and_date_from_text(block_text):
+    """
+    Extrae raw_number, fecha_iso, serie, num_str a partir del texto del bloque.
+    """
+    if not block_text:
+        return None, None, None, None
+
+    lines = [l.strip() for l in block_text.splitlines() if l.strip()]
+    raw_number = None
     fecha_iso = None
-    cliente = None
 
-    # buscar número en texto_rect
-    if texto_rect:
-        logging.info(f"Texto directo en rect: {texto_rect[:200]}")
-        m = RE_FACTURA.search(texto_rect)
+    # buscar línea con 'Factura'
+    idx = None
+    for i, line in enumerate(lines):
+        if re.search(r'\bFactura\b', line, flags=re.IGNORECASE):
+            idx = i
+            break
+
+    candidate = None
+    if idx is not None:
+        line = lines[idx]
+        if ':' in line and re.search(r':\s*\S+', line):
+            after = line.split(':', 1)[1].strip()
+            if after:
+                candidate = after
+        if not candidate and idx + 1 < len(lines):
+            candidate = lines[idx + 1]
+
+    if not candidate:
+        for line in lines:
+            m = re.search(r'Factura[:\s]*', line, flags=re.IGNORECASE)
+            if m:
+                after = line[m.end():].strip()
+                if after:
+                    candidate = after
+                    break
+        if not candidate:
+            candidate = lines[0] if lines else None
+
+    if candidate:
+        raw_number = candidate.strip()
+
+    # extraer fecha si aparece
+    for line in lines:
+        m = RE_FECHA.search(line)
         if m:
-            cand = m.group(1).strip()
-            dm = RE_FACTURA_NUM.search(cand)
-            if dm:
-                numero = dm.group(1)
-        mf = RE_FECHA.search(texto_rect)
-        if mf:
-            fecha_raw = mf.group(1)
             try:
-                d = datetime.strptime(fecha_raw, "%d/%m/%Y")
+                d = datetime.datetime.strptime(m.group(1), "%d/%m/%Y")
                 fecha_iso = d.strftime("%Y-%m-%d")
             except Exception:
                 fecha_iso = None
+            break
 
-    # 2) si no hay texto directo o falta datos, aplicar OCR a la zona
-    if not numero or not fecha_iso:
-        img = render_rect_image(page, rect)
-        if img:
-            proc = preprocess_for_ocr(img)
-            ocr_text = ocr_image_to_text(proc, config="--psm 6")
-            logging.info(f"OCR zona: {ocr_text.strip()[:250]}")
-            if not numero:
-                m = RE_FACTURA.search(ocr_text)
-                if m:
-                    cand = m.group(1).strip()
-                    dm = RE_FACTURA_NUM.search(cand)
-                    if dm:
-                        numero = dm.group(1)
-            if not fecha_iso:
-                mf = RE_FECHA.search(ocr_text)
-                if mf:
-                    fecha_raw = mf.group(1)
-                    try:
-                        d = datetime.strptime(fecha_raw, "%d/%m/%Y")
-                        fecha_iso = d.strftime("%Y-%m-%d")
-                    except Exception:
-                        fecha_iso = None
-
-    # 3) extraer cliente: buscamos bloques en la zona superior-derecha de la página
-    try:
-        page_w = page.rect.width
-        page_h = page.rect.height
-        # definir zona superior-derecha como: x > 50% ancho, y < 35% alto
-        blocks = page.get_text("blocks")
-        cand_blocks = []
-        for b in blocks:
-            x0,y0,x1,y1, btext, _ = b
-            if x0 > page_w * 0.45 and y0 < page_h * 0.35:
-                cand_blocks.append((y0, btext.strip()))
-        # ordenar por y (de arriba abajo)
-        cand_blocks.sort(key=lambda x: x[0])
-        # buscar primer bloque con línea en mayúsculas superior a 2 caracteres
-        for _, btext in cand_blocks:
-            for line in btext.splitlines():
-                line2 = line.strip()
-                if line2 and line2.isupper() and len(line2) > 2:
-                    cliente = limpiar_nombre_cliente(line2)
-                    break
-            if cliente:
-                break
-        # si no encontrado, intentar en todo el texto superior con OCR
-        if not cliente:
-            # tomar región superior completa y OCR
-            sup_rect = fitz.Rect(cm_to_points(10.0), 0, page_w, cm_to_points(4.5))  # ejemplo ancho derecha
-            try:
-                sup_img = render_rect_image(page, sup_rect)
-                if sup_img:
-                    proc2 = preprocess_for_ocr(sup_img)
-                    t2 = ocr_image_to_text(proc2, config="--psm 6")
-                    for line in t2.splitlines():
-                        if line.strip() and line.strip().isupper() and len(line.strip()) > 2:
-                            cliente = limpiar_nombre_cliente(line.strip())
-                            break
-            except Exception:
-                pass
-    except Exception as e:
-        logging.error(f"Error extrayendo cliente: {e}")
-
-    return numero, fecha_iso, cliente, texto_rect
-
-# -------------------- FUNCIONES DE AGRUPACIÓN Y ESCRITURA --------------------
-def agrupar_y_escribir(input_pdf_path, output_dir):
-    """
-    Lee el PDF completo, detecta número por página, agrupa páginas consecutivas
-    con el mismo número y escribe PDFs individuales renombrados.
-    """
-    logging.info(f"Procesando archivo: {input_pdf_path}")
-    os.makedirs(output_dir, exist_ok=True)
-
-    reader = PdfReader(input_pdf_path)
-    num_pages = len(reader.pages)
-    logging.info(f"Páginas encontradas: {num_pages}")
-
-    # Datos por página
-    paginas_info = []  # lista de dicts: {page_index, numero, fecha, cliente, debug_text}
-    doc = fitz.open(input_pdf_path)
-
-    for i in range(num_pages):
-        page = doc.load_page(i)
-        numero, fecha_iso, cliente, debug_text = detectar_en_pagina(page)
-        paginas_info.append({
-            "idx": i,
-            "numero": numero,
-            "fecha": fecha_iso,
-            "cliente": cliente,
-            "debug": debug_text
-        })
-        logging.info(f"Página {i+1}: num={numero} fecha={fecha_iso} cliente={cliente}")
-
-    # Agrupar páginas: cuando aparece un número no-nulo se inicia un nuevo grupo.
-    grupos = []
-    current = None
-    for info in paginas_info:
-        if info["numero"]:
-            # iniciar nuevo grupo
-            if current:
-                grupos.append(current)
-            current = {
-                "numero": info["numero"],
-                "fecha": info["fecha"],
-                "cliente": info["cliente"],
-                "pages": [info["idx"]]
-            }
-        else:
-            # sin número: si hay grupo en curso, añadir; si no, acumular en un grupo 'unknown'
-            if current:
-                current["pages"].append(info["idx"])
+    # intentar extraer serie+numero con normalización robusta
+    serie = None
+    num_str = None
+    if raw_number:
+        norm = normalize_numeric_part(raw_number)
+        if norm:
+            # norm puede devolver ("SERIE", "123") o ("", "123")
+            if isinstance(norm, tuple):
+                serie_part, num_part = norm
+                serie = serie_part if serie_part else None
+                num_str = num_part
             else:
-                # grupo anonimo hasta encontrar numero: crear con numero None
-                current = {
-                    "numero": None,
-                    "fecha": None,
-                    "cliente": None,
-                    "pages": [info["idx"]]
-                }
-    if current:
-        grupos.append(current)
+                # si por alguna razón devuelve un solo valor, lo tomamos como num_str
+                num_str = str(norm)
 
-    logging.info(f"Grupos detectados: {len(grupos)}")
+    return raw_number, fecha_iso, serie, num_str
 
-    # Si el primer grupo no tiene número y el siguiente sí, asignar ese número al primer grupo (caso encabezamiento)
-    if len(grupos) >= 2 and grupos[0]["numero"] is None and grupos[1]["numero"]:
-        logging.info("Primer grupo sin número; asignando número del siguiente grupo (posible encabezamiento).")
-        grupos[0]["numero"] = grupos[1]["numero"]
-        grupos[0]["fecha"] = grupos[1]["fecha"]
-        grupos[0]["cliente"] = grupos[1]["cliente"]
+# -------------------- GUARDADO --------------------
+def save_invoice_pdf_from_reader(reader, page_indexes, outdir, fecha_iso, serie, num_str, raw_number):
+    os.makedirs(outdir, exist_ok=True)
 
-    escritos = 0
-    fallidos = []
+    if num_str:
+        num_pad = str(num_str).zfill(4)
+        fecha_txt = fecha_iso if fecha_iso else "0000-00-00"
+        serie_txt = f" {serie}" if serie else ""
+        filename = f"{fecha_txt} FE#{num_pad}{serie_txt}.pdf"
+    else:
+        safe_raw = re.sub(r'[\/\\\:\*\?\"\<\>\|]', '_', (raw_number or "SIN_NUMERO")).strip()
+        fecha_txt = fecha_iso if fecha_iso else "0000-00-00"
+        filename = f"{fecha_txt} {safe_raw}.pdf"
 
-    for g in grupos:
-        numero = g["numero"]
-        fecha = g["fecha"]
-        cliente = g["cliente"] or "CLIENTE"
-        pages = g["pages"]
+    outpath = os.path.join(outdir, filename)
+    base, ext = os.path.splitext(outpath)
+    counter = 1
+    while os.path.exists(outpath):
+        outpath = f"{base} ({counter}){ext}"
+        counter += 1
 
-        if not numero:
-            logging.warning(f"Grupo sin número (páginas {pages}); se guarda como 'SIN_NUMERO_{pages[0]+1}.pdf'")
-            out_name = f"SIN_NUMERO_{pages[0]+1}.pdf"
-            out_path = os.path.join(output_dir, out_name)
+    writer = PdfWriter()
+    for p in page_indexes:
+        writer.add_page(reader.pages[p])
+    with open(outpath, 'wb') as f:
+        writer.write(f)
+
+    logging.info(f"Guardado: {outpath}")
+    return outpath
+
+# -------------------- PROCESAMIENTO PRINCIPAL --------------------
+def make_key_from_parts(serie, num_str, raw_number):
+    """
+    Genera una clave canónica para comparar facturas entre páginas.
+    Prioriza serie+num_str si existe; si no, intenta normalizar raw_number.
+    """
+    if num_str:
+        s = (serie or "").upper()
+        return f"{s}#{str(num_str).zfill(4)}"
+    if raw_number:
+        # extraer mediante normalize_numeric_part (aplicar same mapping)
+        norm = normalize_numeric_part(raw_number)
+        if norm and isinstance(norm, tuple):
+            s_part, n_part = norm
+            s_part = s_part.upper() if s_part else ""
+            return f"{s_part}#{str(n_part).zfill(4)}"
+        # fallback: usar RAW con texto limpio compactado
+        raw_clean = re.sub(r'\s+', ' ', raw_number).strip()
+        return f"RAW#{raw_clean}"
+    return None
+
+def procesar_pdf_separar(input_pdf_path, output_dir, progress_callback=None, status_callback=None):
+    try:
+        reader = PdfReader(input_pdf_path)
+    except Exception as e:
+        logging.exception("No se pudo abrir PDF")
+        if status_callback:
+            status_callback(f"ERROR abriendo PDF: {e}")
+        return 0, []
+
+    doc = fitz.open(input_pdf_path)  # para render / imagen
+    total_pages = len(doc)
+    results_saved = []
+    processed_invoices = 0
+
+    current_number_key = None
+    current_pages = []
+    current_fecha = None
+    current_serie = None
+    current_num_str = None
+    current_raw = None
+
+    for i in range(total_pages):
+        if progress_callback:
+            progress_callback(i + 1, total_pages)
+        if status_callback:
+            status_callback(f"Procesando página {i+1}/{total_pages}")
+
+        page = doc[i]
+        pil_img = render_page_to_image(page, zoom=RENDER_ZOOM)
+        cropped = crop_region_from_image(pil_img, page.rect.width, page.rect.height)
+        if cropped is None:
+            logging.warning(f"P{i+1}: recorte inválido.")
+            text_block = ""
         else:
-            # número sin ceros -> rellenar a 4 dígitos
-            num_pad = str(numero).zfill(4)
-            # si no hay fecha, intentar buscar la primera página del grupo para la fecha
-            if not fecha:
-                # buscar en las páginas del grupo por primera fecha detectada
-                for pidx in pages:
-                    if paginas_info[pidx]["fecha"]:
-                        fecha = paginas_info[pidx]["fecha"]
-                        break
-            fecha_final = fecha if fecha else "0000-00-00"
-            # cliente limpiar
-            cliente_clean = limpiar_nombre_cliente(cliente)
-            out_name = f"{fecha_final} FE#{num_pad} {cliente_clean}.pdf"
-            out_path = os.path.join(output_dir, out_name)
+            text_block = ocr_image_to_text(cropped)
 
-        # crear PDF con páginas indicadas
-        try:
-            writer = PdfWriter()
-            for pidx in pages:
-                writer.add_page(reader.pages[pidx])
-            with open(out_path, "wb") as fout:
-                writer.write(fout)
-            escritos += 1
-            logging.info(f"Escrito: {out_name} (páginas {pages})")
-        except Exception as e:
-            logging.error(f"Error escribiendo {out_path}: {e}")
-            fallidos.append((pages, str(e)))
-            # guardar imagen de la primera página del grupo para diagnóstico
-            try:
-                imgsave = os.path.join(FAIL_IMG_DIR, f"grupo_{pages[0]+1}.png")
-                page_img = doc.load_page(pages[0]).get_pixmap(matrix=fitz.Matrix(150/72,150/72))
-                page_img.save(imgsave)
-                logging.info(f"Guardada imagen de fallo: {imgsave}")
-            except Exception as e2:
-                logging.error(f"No se pudo guardar imagen de fallo: {e2}")
+        raw_number, fecha_iso, serie, num_str = extract_number_and_date_from_text(text_block)
+        logging.info(f"P{i+1}: raw='{raw_number}' fecha='{fecha_iso}' serie='{serie}' num='{num_str}'")
 
-    logging.info(f"Escritos: {escritos} documentos. Fallidos: {len(fallidos)}")
-    return escritos, fallidos
+        key = make_key_from_parts(serie, num_str, raw_number)
+        logging.debug(f"P{i+1}: key generated -> {key}")
 
-# -------------------- INTERFAZ SIMPLE (Tk) --------------------
+        if key is None:
+            logging.warning(f"No se detectó número en página {i+1}. Texto OCR: '{(text_block or '')[:160]}'")
+            if current_number_key is None:
+                continue
+            else:
+                current_pages.append(i)
+                continue
+
+        # Si no hay factura en curso -> iniciar
+        if current_number_key is None:
+            current_number_key = key
+            current_pages = [i]
+            current_fecha = fecha_iso
+            current_serie = serie
+            current_num_str = num_str
+            current_raw = raw_number
+            logging.debug(f"P{i+1}: inicia factura {current_number_key}")
+            continue
+
+        # Si la clave ha cambiado -> guardar la anterior y comenzar nueva
+        if key != current_number_key:
+            saved_path = save_invoice_pdf_from_reader(reader, current_pages, output_dir,
+                                                     current_fecha, current_serie, current_num_str, current_raw)
+            results_saved.append(saved_path)
+            processed_invoices += 1
+            logging.debug(f"P{i+1}: cerrada factura {current_number_key} -> guardada {saved_path}")
+            # iniciar nueva factura
+            current_number_key = key
+            current_pages = [i]
+            current_fecha = fecha_iso
+            current_serie = serie
+            current_num_str = num_str
+            current_raw = raw_number
+        else:
+            # misma factura -> añadir página
+            current_pages.append(i)
+            logging.debug(f"P{i+1}: añadida a factura {current_number_key}")
+
+    # guardar la última factura en curso
+    if current_pages and current_number_key is not None:
+        saved_path = save_invoice_pdf_from_reader(reader, current_pages, output_dir,
+                                                 current_fecha, current_serie, current_num_str, current_raw)
+        results_saved.append(saved_path)
+        processed_invoices += 1
+
+    doc.close()
+    logging.info(f"Proceso terminado. Facturas generadas: {processed_invoices}")
+    if status_callback:
+        status_callback(f"Proceso terminado. Facturas generadas: {processed_invoices}")
+    return processed_invoices, results_saved
+
+# -------------------- INTERFAZ GRÁFICA (Tk) --------------------
 class AppSeparador:
     def __init__(self, root):
         self.root = root
-        root.title("Separar facturas")
-        root.geometry("620x220")
+        root.title("Separador de Facturas")
+        root.geometry("700x360")
         root.resizable(False, False)
 
-        self.label = tk.Label(root, text="Separar PDF de facturas en archivos individuales", font=("Segoe UI", 11))
-        self.label.pack(pady=8)
+        frame = tk.Frame(root, padx=12, pady=10)
+        frame.pack(fill=tk.BOTH, expand=False)
 
-        frame = tk.Frame(root)
-        frame.pack(pady=6)
+        tk.Label(frame, text="PDF origen con múltiples facturas:", anchor="w").grid(row=0, column=0, sticky="w")
+        self.entry_pdf = tk.Entry(frame, width=70)
+        self.entry_pdf.grid(row=1, column=0, columnspan=2, pady=4, sticky="w")
+        tk.Button(frame, text="Seleccionar PDF", command=self.select_pdf).grid(row=1, column=2, padx=6)
 
-        self.btn_input = tk.Button(frame, text="Seleccionar PDF origen", width=20, command=self.select_input)
-        self.btn_input.pack(side=tk.LEFT, padx=6)
-        self.lbl_input = tk.Label(frame, text="Ninguno")
-        self.lbl_input.pack(side=tk.LEFT, padx=6)
+        tk.Label(frame, text="Carpeta destino para facturas separadas:", anchor="w").grid(row=2, column=0, sticky="w")
+        self.entry_out = tk.Entry(frame, width=70)
+        self.entry_out.grid(row=3, column=0, columnspan=2, pady=4, sticky="w")
+        tk.Button(frame, text="Seleccionar carpeta", command=self.select_out).grid(row=3, column=2, padx=6)
 
-        self.btn_dest = tk.Button(frame, text="Seleccionar carpeta destino", width=22, command=self.select_output)
-        self.btn_dest.pack(side=tk.LEFT, padx=6)
-        self.lbl_dest = tk.Label(frame, text="Ninguno")
-        self.lbl_dest.pack(side=tk.LEFT, padx=6)
+        self.progress = ttk.Progressbar(root, orient='horizontal', mode='determinate', length=640)
+        self.progress.pack(pady=8)
+        self.status_var = tk.StringVar(value="Listo")
+        self.status_label = tk.Label(root, textvariable=self.status_var, anchor="w")
+        self.status_label.pack(fill=tk.X, padx=12)
 
-        self.progress = ttk.Progressbar(root, orient='horizontal', mode='indeterminate', length=560)
-        self.progress.pack(pady=12)
-        self.progress.stop()
-
-        self.text = tk.Text(root, height=6, width=78)
-        self.text.pack(padx=6, pady=4)
-        self.text.insert(tk.END, "Seleccione el PDF origen y la carpeta destino y pulse Iniciar.\n")
-        self.text.config(state=tk.DISABLED)
-
-        frame2 = tk.Frame(root)
-        frame2.pack(pady=4)
-        self.btn_start = tk.Button(frame2, text="Iniciar", command=self.start, width=12)
+        btn_frame = tk.Frame(root, pady=6)
+        btn_frame.pack()
+        self.btn_start = tk.Button(btn_frame, text="INICIAR SEPARACIÓN", bg="#4CAF50", fg="white",
+                                   font=("Arial", 11, "bold"), command=self.start_process)
         self.btn_start.pack(side=tk.LEFT, padx=6)
-        self.btn_quit = tk.Button(frame2, text="Salir", command=root.quit, width=12)
-        self.btn_quit.pack(side=tk.LEFT, padx=6)
+        tk.Button(btn_frame, text="Salir", command=root.quit).pack(side=tk.LEFT, padx=6)
 
-        self.input_pdf = None
-        self.output_dir = None
+        configurar_logger()
 
-    def log(self, s):
-        self.text.config(state=tk.NORMAL)
-        self.text.insert(tk.END, s + "\n")
-        self.text.see(tk.END)
-        self.text.config(state=tk.DISABLED)
-        self.root.update()
+    def select_pdf(self):
+        p = filedialog.askopenfilename(title="Seleccionar PDF", filetypes=[("PDF files", "*.pdf")])
+        if p:
+            self.entry_pdf.delete(0, tk.END)
+            self.entry_pdf.insert(0, p)
 
-    def select_input(self):
-        path = filedialog.askopenfilename(title="Seleccionar PDF de facturas", filetypes=[("PDF Files", "*.pdf")])
-        if path:
-            self.input_pdf = path
-            self.lbl_input.config(text=os.path.basename(path))
+    def select_out(self):
+        p = filedialog.askdirectory(title="Seleccionar carpeta destino")
+        if p:
+            self.entry_out.delete(0, tk.END)
+            self.entry_out.insert(0, p)
 
-    def select_output(self):
-        path = filedialog.askdirectory(title="Seleccionar carpeta destino")
-        if path:
-            self.output_dir = path
-            self.lbl_dest.config(text=path)
+    def progress_callback(self, current, total):
+        try:
+            self.progress['maximum'] = total
+            self.progress['value'] = current
+            self.status_var.set(f"Procesando página {current} de {total}")
+            self.root.update_idletasks()
+        except Exception:
+            pass
 
-    def start(self):
-        if not self.input_pdf:
-            messagebox.showwarning("Falta", "Seleccione el PDF de facturas a procesar.")
+    def status_callback(self, msg):
+        self.status_var.set(msg)
+        logging.info(msg)
+        self.root.update_idletasks()
+
+    def start_process(self):
+        input_pdf = self.entry_pdf.get().strip()
+        output_dir = self.entry_out.get().strip()
+        if not input_pdf or not output_dir:
+            messagebox.showwarning("Faltan datos", "Seleccione el PDF origen y la carpeta destino.")
             return
-        if not self.output_dir:
-            messagebox.showwarning("Falta", "Seleccione la carpeta destino.")
-            return
 
-        logpath = configurar_logger()
-        self.log(f"Iniciando: {os.path.basename(self.input_pdf)}")
-        self.progress.start(10)
-        self.root.update()
+        self.btn_start.config(state=tk.DISABLED)
+        self.status_callback("Iniciando proceso...")
+        self.progress['value'] = 0
+        self.root.update_idletasks()
 
-        escritos, fallidos = agrupar_y_escribir(self.input_pdf, self.output_dir)
+        thread = threading.Thread(target=self._run_process, args=(input_pdf, output_dir), daemon=True)
+        thread.start()
 
-        self.progress.stop()
-        self.log(f"Proceso finalizado. Escritos: {escritos}. Fallidos: {len(fallidos)}")
-        self.log(f"Log: {logpath}")
-        messagebox.showinfo("Finalizado", f"Facturas generadas: {escritos}\nFallidos: {len(fallidos)}\nLog: {logpath}")
+    def _run_process(self, input_pdf, output_dir):
+        try:
+            processed_count, saved_paths = procesar_pdf_separar(
+                input_pdf, output_dir,
+                progress_callback=self.progress_callback,
+                status_callback=self.status_callback
+            )
+            msg = f"Proceso finalizado. Facturas generadas: {processed_count}"
+            messagebox.showinfo("Finalizado", msg)
+            self.status_callback(msg)
+        except Exception as e:
+            logging.exception("Error en proceso principal")
+            messagebox.showerror("Error", f"Ha ocurrido un error durante el proceso:\n{e}")
+            self.status_callback(f"ERROR: {e}")
+        finally:
+            self.btn_start.config(state=tk.NORMAL)
 
-# -------------------- EJECUCIÓN --------------------
 def main():
     root = tk.Tk()
     app = AppSeparador(root)

--- a/src/separar_facturas.py
+++ b/src/separar_facturas.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+separar_facturas.py
+Módulo para dividir un PDF que contiene muchas facturas en PDFs individuales por factura.
+Detecta número de factura y fecha en el rectángulo superior-izq (coordenadas en cm), 
+extrae nombre de cliente desde bloques en la zona superior-derecha y renombra cada PDF
+según el patrón: YYYY-MM-DD FE#NNNN NOMBRE_CLIENTE.pdf
+
+Requisitos:
+  pip install PyMuPDF Pillow pytesseract pypdf
+  Tesseract instalado en: C:\Program Files\Tesseract-OCR\tesseract.exe
+"""
+
+import os
+import re
+import logging
+import shutil
+from datetime import datetime
+from io import BytesIO
+
+import fitz  # PyMuPDF
+from PIL import Image, ImageOps, ImageFilter, ImageEnhance
+import pytesseract
+from pypdf import PdfReader, PdfWriter
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+# -------------------- CONFIGURACIÓN --------------------
+# Ruta a tesseract (confirmada)
+pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+
+# Rectángulo del número/fecha de factura (cm desde borde superior-izq)
+RECT_FACT_LEFT_CM = 0.7
+RECT_FACT_TOP_CM = 5.7
+RECT_FACT_RIGHT_CM = 7.6
+RECT_FACT_BOTTOM_CM = 7.5
+PAD_CM = 0.15  # pequeño padding por seguridad
+
+# DPI para renderizado
+RENDER_DPI = 300
+
+# Carpeta de logs
+LOGS_DIR = "logs"
+FAIL_IMG_DIR = os.path.join(LOGS_DIR, "fails_images")
+
+# Regex para detectar número de factura y fecha
+RE_FACTURA = re.compile(r'Factura[:\s]*([A-Za-z0-9\-/]+|\d{1,})', re.IGNORECASE)  # captura lo que sigue a "Factura:"
+# Si las facturas numericas son solo dígitos, lo extraemos con:
+RE_FACTURA_NUM = re.compile(r'(\d{1,})')
+RE_FECHA = re.compile(r'Fecha[:\s]*([0-3]?\d/[01]?\d/[12]\d{3})', re.IGNORECASE)
+
+# Sufijos societarios a eliminar del nombre del cliente
+SUFFIXES_RE = re.compile(r'\b(SL|SA|SLU|SCOOP|SLL|SCOOPG|SC|S\.L\.|S\.A\.)\b\.?$', re.IGNORECASE)
+
+# -------------------- UTILIDADES --------------------
+def configurar_logger():
+    os.makedirs(LOGS_DIR, exist_ok=True)
+    os.makedirs(FAIL_IMG_DIR, exist_ok=True)
+    logname = datetime.now().strftime("separar_facturas_%Y%m%d_%H%M%S.log")
+    logpath = os.path.join(LOGS_DIR, logname)
+    logging.basicConfig(filename=logpath,
+                        level=logging.INFO,
+                        format="%(asctime)s - %(levelname)s - %(message)s")
+    logging.info("=== INICIO: separar_facturas ===")
+    return logpath
+
+def cm_to_points(cm):
+    return cm * (72.0 / 2.54)
+
+def limpiar_nombre_cliente(nombre: str) -> str:
+    if not nombre:
+        return "CLIENTE"
+    s = nombre.strip()
+    s = s.replace('.', '')
+    s = re.sub(SUFFIXES_RE, '', s).strip()
+    s = re.sub(r'\s{2,}', ' ', s)
+    s = re.sub(r'[\/\\\:\*\?\"\<\>\|]', '_', s)
+    return s.upper()
+
+# Extrae texto del bloque de interés usando PyMuPDF blocks
+def extraer_texto_rect(page, rect):
+    """
+    Devuelve el texto extraído dentro del rect (fitz.Rect)
+    """
+    try:
+        blocks = page.get_text("blocks")  # lista de (x0,y0,x1,y1, "text", block_no)
+    except Exception as e:
+        logging.error(f"get_text('blocks') falló: {e}")
+        return ""
+    textos = []
+    for b in blocks:
+        x0, y0, x1, y1, btext, _ = b
+        # comprobar intersección con rect
+        if x1 >= rect.x0 and x0 <= rect.x1 and y1 >= rect.y0 and y0 <= rect.y1:
+            textos.append(btext)
+    return "\n".join(textos).strip()
+
+def render_rect_image(page, rect, dpi=RENDER_DPI):
+    """
+    Renderiza la región rect (fitz.Rect) de la página a PIL.Image RGB.
+    """
+    try:
+        mat = fitz.Matrix(dpi/72.0, dpi/72.0)
+        pix = page.get_pixmap(matrix=mat, clip=rect, alpha=False)
+        img = Image.open(BytesIO(pix.tobytes("png"))).convert("RGB")
+        return img
+    except Exception as e:
+        logging.error(f"render_rect_image falló: {e}")
+        return None
+
+def preprocess_for_ocr(img: Image.Image) -> Image.Image:
+    """
+    Preprocesado simple para OCR: escala, gris, contraste, unsharp
+    """
+    img = img.convert("RGB")
+    w,h = img.size
+    img = img.resize((int(w*2), int(h*2)), Image.BICUBIC)
+    gray = ImageOps.grayscale(img)
+    enh = ImageEnhance.Contrast(gray)
+    gray = enh.enhance(1.3)
+    gray = gray.filter(ImageFilter.MedianFilter(size=3))
+    gray = gray.filter(ImageFilter.UnsharpMask(radius=1, percent=120, threshold=3))
+    return gray
+
+def ocr_image_to_text(img: Image.Image, config="--psm 6"):
+    try:
+        text = pytesseract.image_to_string(img, lang='spa', config=config)
+        return text
+    except Exception as e:
+        logging.error(f"OCR falló: {e}")
+        return ""
+
+# -------------------- LÓGICA DE DETECCIÓN EN UNA PÁGINA --------------------
+def detectar_en_pagina(page):
+    """
+    Detecta número de factura, fecha y cliente en una página (fitz page).
+    Devuelve (numero_string_or_None, fecha_iso_or_None, cliente_or_None, debug_text)
+    """
+    # calcular rect en puntos
+    left = cm_to_points(max(0.0, RECT_FACT_LEFT_CM - PAD_CM))
+    top = cm_to_points(max(0.0, RECT_FACT_TOP_CM - PAD_CM))
+    right = cm_to_points(RECT_FACT_RIGHT_CM + PAD_CM)
+    bottom = cm_to_points(RECT_FACT_BOTTOM_CM + PAD_CM)
+    rect = fitz.Rect(left, top, right, bottom)
+
+    # 1) intentar extraer texto directo de ese rect (si el PDF tiene texto)
+    texto_rect = extraer_texto_rect(page, rect)
+    numero = None
+    fecha_iso = None
+    cliente = None
+
+    # buscar número en texto_rect
+    if texto_rect:
+        logging.info(f"Texto directo en rect: {texto_rect[:200]}")
+        m = RE_FACTURA.search(texto_rect)
+        if m:
+            cand = m.group(1).strip()
+            dm = RE_FACTURA_NUM.search(cand)
+            if dm:
+                numero = dm.group(1)
+        mf = RE_FECHA.search(texto_rect)
+        if mf:
+            fecha_raw = mf.group(1)
+            try:
+                d = datetime.strptime(fecha_raw, "%d/%m/%Y")
+                fecha_iso = d.strftime("%Y-%m-%d")
+            except Exception:
+                fecha_iso = None
+
+    # 2) si no hay texto directo o falta datos, aplicar OCR a la zona
+    if not numero or not fecha_iso:
+        img = render_rect_image(page, rect)
+        if img:
+            proc = preprocess_for_ocr(img)
+            ocr_text = ocr_image_to_text(proc, config="--psm 6")
+            logging.info(f"OCR zona: {ocr_text.strip()[:250]}")
+            if not numero:
+                m = RE_FACTURA.search(ocr_text)
+                if m:
+                    cand = m.group(1).strip()
+                    dm = RE_FACTURA_NUM.search(cand)
+                    if dm:
+                        numero = dm.group(1)
+            if not fecha_iso:
+                mf = RE_FECHA.search(ocr_text)
+                if mf:
+                    fecha_raw = mf.group(1)
+                    try:
+                        d = datetime.strptime(fecha_raw, "%d/%m/%Y")
+                        fecha_iso = d.strftime("%Y-%m-%d")
+                    except Exception:
+                        fecha_iso = None
+
+    # 3) extraer cliente: buscamos bloques en la zona superior-derecha de la página
+    try:
+        page_w = page.rect.width
+        page_h = page.rect.height
+        # definir zona superior-derecha como: x > 50% ancho, y < 35% alto
+        blocks = page.get_text("blocks")
+        cand_blocks = []
+        for b in blocks:
+            x0,y0,x1,y1, btext, _ = b
+            if x0 > page_w * 0.45 and y0 < page_h * 0.35:
+                cand_blocks.append((y0, btext.strip()))
+        # ordenar por y (de arriba abajo)
+        cand_blocks.sort(key=lambda x: x[0])
+        # buscar primer bloque con línea en mayúsculas superior a 2 caracteres
+        for _, btext in cand_blocks:
+            for line in btext.splitlines():
+                line2 = line.strip()
+                if line2 and line2.isupper() and len(line2) > 2:
+                    cliente = limpiar_nombre_cliente(line2)
+                    break
+            if cliente:
+                break
+        # si no encontrado, intentar en todo el texto superior con OCR
+        if not cliente:
+            # tomar región superior completa y OCR
+            sup_rect = fitz.Rect(cm_to_points(10.0), 0, page_w, cm_to_points(4.5))  # ejemplo ancho derecha
+            try:
+                sup_img = render_rect_image(page, sup_rect)
+                if sup_img:
+                    proc2 = preprocess_for_ocr(sup_img)
+                    t2 = ocr_image_to_text(proc2, config="--psm 6")
+                    for line in t2.splitlines():
+                        if line.strip() and line.strip().isupper() and len(line.strip()) > 2:
+                            cliente = limpiar_nombre_cliente(line.strip())
+                            break
+            except Exception:
+                pass
+    except Exception as e:
+        logging.error(f"Error extrayendo cliente: {e}")
+
+    return numero, fecha_iso, cliente, texto_rect
+
+# -------------------- FUNCIONES DE AGRUPACIÓN Y ESCRITURA --------------------
+def agrupar_y_escribir(input_pdf_path, output_dir):
+    """
+    Lee el PDF completo, detecta número por página, agrupa páginas consecutivas
+    con el mismo número y escribe PDFs individuales renombrados.
+    """
+    logging.info(f"Procesando archivo: {input_pdf_path}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    reader = PdfReader(input_pdf_path)
+    num_pages = len(reader.pages)
+    logging.info(f"Páginas encontradas: {num_pages}")
+
+    # Datos por página
+    paginas_info = []  # lista de dicts: {page_index, numero, fecha, cliente, debug_text}
+    doc = fitz.open(input_pdf_path)
+
+    for i in range(num_pages):
+        page = doc.load_page(i)
+        numero, fecha_iso, cliente, debug_text = detectar_en_pagina(page)
+        paginas_info.append({
+            "idx": i,
+            "numero": numero,
+            "fecha": fecha_iso,
+            "cliente": cliente,
+            "debug": debug_text
+        })
+        logging.info(f"Página {i+1}: num={numero} fecha={fecha_iso} cliente={cliente}")
+
+    # Agrupar páginas: cuando aparece un número no-nulo se inicia un nuevo grupo.
+    grupos = []
+    current = None
+    for info in paginas_info:
+        if info["numero"]:
+            # iniciar nuevo grupo
+            if current:
+                grupos.append(current)
+            current = {
+                "numero": info["numero"],
+                "fecha": info["fecha"],
+                "cliente": info["cliente"],
+                "pages": [info["idx"]]
+            }
+        else:
+            # sin número: si hay grupo en curso, añadir; si no, acumular en un grupo 'unknown'
+            if current:
+                current["pages"].append(info["idx"])
+            else:
+                # grupo anonimo hasta encontrar numero: crear con numero None
+                current = {
+                    "numero": None,
+                    "fecha": None,
+                    "cliente": None,
+                    "pages": [info["idx"]]
+                }
+    if current:
+        grupos.append(current)
+
+    logging.info(f"Grupos detectados: {len(grupos)}")
+
+    # Si el primer grupo no tiene número y el siguiente sí, asignar ese número al primer grupo (caso encabezamiento)
+    if len(grupos) >= 2 and grupos[0]["numero"] is None and grupos[1]["numero"]:
+        logging.info("Primer grupo sin número; asignando número del siguiente grupo (posible encabezamiento).")
+        grupos[0]["numero"] = grupos[1]["numero"]
+        grupos[0]["fecha"] = grupos[1]["fecha"]
+        grupos[0]["cliente"] = grupos[1]["cliente"]
+
+    escritos = 0
+    fallidos = []
+
+    for g in grupos:
+        numero = g["numero"]
+        fecha = g["fecha"]
+        cliente = g["cliente"] or "CLIENTE"
+        pages = g["pages"]
+
+        if not numero:
+            logging.warning(f"Grupo sin número (páginas {pages}); se guarda como 'SIN_NUMERO_{pages[0]+1}.pdf'")
+            out_name = f"SIN_NUMERO_{pages[0]+1}.pdf"
+            out_path = os.path.join(output_dir, out_name)
+        else:
+            # número sin ceros -> rellenar a 4 dígitos
+            num_pad = str(numero).zfill(4)
+            # si no hay fecha, intentar buscar la primera página del grupo para la fecha
+            if not fecha:
+                # buscar en las páginas del grupo por primera fecha detectada
+                for pidx in pages:
+                    if paginas_info[pidx]["fecha"]:
+                        fecha = paginas_info[pidx]["fecha"]
+                        break
+            fecha_final = fecha if fecha else "0000-00-00"
+            # cliente limpiar
+            cliente_clean = limpiar_nombre_cliente(cliente)
+            out_name = f"{fecha_final} FE#{num_pad} {cliente_clean}.pdf"
+            out_path = os.path.join(output_dir, out_name)
+
+        # crear PDF con páginas indicadas
+        try:
+            writer = PdfWriter()
+            for pidx in pages:
+                writer.add_page(reader.pages[pidx])
+            with open(out_path, "wb") as fout:
+                writer.write(fout)
+            escritos += 1
+            logging.info(f"Escrito: {out_name} (páginas {pages})")
+        except Exception as e:
+            logging.error(f"Error escribiendo {out_path}: {e}")
+            fallidos.append((pages, str(e)))
+            # guardar imagen de la primera página del grupo para diagnóstico
+            try:
+                imgsave = os.path.join(FAIL_IMG_DIR, f"grupo_{pages[0]+1}.png")
+                page_img = doc.load_page(pages[0]).get_pixmap(matrix=fitz.Matrix(150/72,150/72))
+                page_img.save(imgsave)
+                logging.info(f"Guardada imagen de fallo: {imgsave}")
+            except Exception as e2:
+                logging.error(f"No se pudo guardar imagen de fallo: {e2}")
+
+    logging.info(f"Escritos: {escritos} documentos. Fallidos: {len(fallidos)}")
+    return escritos, fallidos
+
+# -------------------- INTERFAZ SIMPLE (Tk) --------------------
+class AppSeparador:
+    def __init__(self, root):
+        self.root = root
+        root.title("Separar facturas")
+        root.geometry("620x220")
+        root.resizable(False, False)
+
+        self.label = tk.Label(root, text="Separar PDF de facturas en archivos individuales", font=("Segoe UI", 11))
+        self.label.pack(pady=8)
+
+        frame = tk.Frame(root)
+        frame.pack(pady=6)
+
+        self.btn_input = tk.Button(frame, text="Seleccionar PDF origen", width=20, command=self.select_input)
+        self.btn_input.pack(side=tk.LEFT, padx=6)
+        self.lbl_input = tk.Label(frame, text="Ninguno")
+        self.lbl_input.pack(side=tk.LEFT, padx=6)
+
+        self.btn_dest = tk.Button(frame, text="Seleccionar carpeta destino", width=22, command=self.select_output)
+        self.btn_dest.pack(side=tk.LEFT, padx=6)
+        self.lbl_dest = tk.Label(frame, text="Ninguno")
+        self.lbl_dest.pack(side=tk.LEFT, padx=6)
+
+        self.progress = ttk.Progressbar(root, orient='horizontal', mode='indeterminate', length=560)
+        self.progress.pack(pady=12)
+        self.progress.stop()
+
+        self.text = tk.Text(root, height=6, width=78)
+        self.text.pack(padx=6, pady=4)
+        self.text.insert(tk.END, "Seleccione el PDF origen y la carpeta destino y pulse Iniciar.\n")
+        self.text.config(state=tk.DISABLED)
+
+        frame2 = tk.Frame(root)
+        frame2.pack(pady=4)
+        self.btn_start = tk.Button(frame2, text="Iniciar", command=self.start, width=12)
+        self.btn_start.pack(side=tk.LEFT, padx=6)
+        self.btn_quit = tk.Button(frame2, text="Salir", command=root.quit, width=12)
+        self.btn_quit.pack(side=tk.LEFT, padx=6)
+
+        self.input_pdf = None
+        self.output_dir = None
+
+    def log(self, s):
+        self.text.config(state=tk.NORMAL)
+        self.text.insert(tk.END, s + "\n")
+        self.text.see(tk.END)
+        self.text.config(state=tk.DISABLED)
+        self.root.update()
+
+    def select_input(self):
+        path = filedialog.askopenfilename(title="Seleccionar PDF de facturas", filetypes=[("PDF Files", "*.pdf")])
+        if path:
+            self.input_pdf = path
+            self.lbl_input.config(text=os.path.basename(path))
+
+    def select_output(self):
+        path = filedialog.askdirectory(title="Seleccionar carpeta destino")
+        if path:
+            self.output_dir = path
+            self.lbl_dest.config(text=path)
+
+    def start(self):
+        if not self.input_pdf:
+            messagebox.showwarning("Falta", "Seleccione el PDF de facturas a procesar.")
+            return
+        if not self.output_dir:
+            messagebox.showwarning("Falta", "Seleccione la carpeta destino.")
+            return
+
+        logpath = configurar_logger()
+        self.log(f"Iniciando: {os.path.basename(self.input_pdf)}")
+        self.progress.start(10)
+        self.root.update()
+
+        escritos, fallidos = agrupar_y_escribir(self.input_pdf, self.output_dir)
+
+        self.progress.stop()
+        self.log(f"Proceso finalizado. Escritos: {escritos}. Fallidos: {len(fallidos)}")
+        self.log(f"Log: {logpath}")
+        messagebox.showinfo("Finalizado", f"Facturas generadas: {escritos}\nFallidos: {len(fallidos)}\nLog: {logpath}")
+
+# -------------------- EJECUCIÓN --------------------
+def main():
+    root = tk.Tk()
+    app = AppSeparador(root)
+    root.mainloop()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Este commit actualiza `separar_facturas.py` (ubicado en src/) con la versión corregida que:
- Agrupa correctamente páginas consecutivas pertenecientes a la misma factura.
- Normaliza la clave de identificación de factura (serie+número) corrigiendo confusiones OCR típicas (O/0, I/1, l/1, Z/2, S/5, B/8).
- Amplía ligeramente el área de recorte para evitar cortes de texto en la zona del número de factura.
- Mantiene interfaz Tk y logging (logs/separar_facturas.log).

Pruebas realizadas: procesado exitoso de PDF de prueba con 63 páginas; facturas multi-página agrupadas correctamente.
